### PR TITLE
fix: fixed pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ addopts = """
     --cov-report term
     --cov-report html
     --cov-report xml
-    --cov=<MODULE_NAME>
+    --cov=ape_beacon
 """
 python_files = "test_*.py"
 testpaths = "tests"


### PR DESCRIPTION
### What I did

`pyproject.toml` had `<MODULE_NAME>` from template in there still. Changed to `ape_beacon`.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
