### PR TITLE
fix: setup.py for types-requests in lint extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
         "mypy>=0.971",  # Static type analyzer
         "flake8>=4.0.1",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
+        "types-requests",  # NOTE: Needed due to mypy typeshed
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool
@@ -57,7 +58,6 @@ setup(
         "hexbytes",  # Use same version as eth-ape
         "web3",  # Use same version as eth-ape
         "responses",  # Use for beacon provider local testing
-        "types-requests",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

Fixes `setup.py` for `extra_requires`

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
