### PR TITLE
fix: beacon provider is also connected when node syncing

### DIFF
--- a/ape_beacon/providers.py
+++ b/ape_beacon/providers.py
@@ -101,8 +101,12 @@ class BeaconProvider(ProviderAPI, ABC):
         if self._beacon is None:
             return False
 
+        # treat as connected if node is fully synced or syncing
         status_code = self._beacon.get_health()
-        return status_code == requests.status_codes.codes.ok
+        return (
+            status_code == requests.status_codes.codes.ok
+            or status_code == requests.status_codes.codes.partial
+        )
 
     def update_settings(self, new_settings: dict):
         self.disconnect()


### PR DESCRIPTION
### What I did

Changed Beacon provider's `is_connect()` to be `True` when either node is syncing or fully synced.

### How I did it

`is_connect()` returns true for status codes 200 or 206.

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
