### PR TITLE
feat: add lighthouse provider

### DIFF
--- a/ape_beacon/__init__.py
+++ b/ape_beacon/__init__.py
@@ -1,8 +1,9 @@
 from ape import plugins
-from ape.api import NetworkAPI, create_network_type
-from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI, create_network_type
 
-from .ecosystem import NETWORKS, Beacon, BeaconConfig
+from .configs import BeaconConfig, LighthouseNetworkConfig
+from .ecosystem import NETWORKS, Beacon
+from .providers import Lighthouse
 
 
 @plugins.register(plugins.Config)
@@ -19,7 +20,12 @@ def ecosystems():
 def networks():
     for network_name, network_params in NETWORKS.items():
         yield "beacon", network_name, create_network_type(*network_params)
-        yield "beacon", f"{network_name}-fork", NetworkAPI
 
     # NOTE: This works for local providers, as they get chain_id from themselves
     yield "beacon", LOCAL_NETWORK_NAME, NetworkAPI
+
+
+@plugins.register(plugins.ProviderPlugin)
+def providers():
+    for network_name in LighthouseNetworkConfig().dict():
+        yield "beacon", network_name, Lighthouse

--- a/ape_beacon/configs.py
+++ b/ape_beacon/configs.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from ape.api import PluginConfig
+from ape.api.networks import LOCAL_NETWORK_NAME
+
+from .providers import DEFAULT_SETTINGS
+
+
+class NetworkConfig(PluginConfig):
+    required_confirmations: int = 0
+    block_time: int = 0
+
+
+def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:
+    return _create_config(required_confirmations=0, **kwargs)
+
+
+def _create_config(required_confirmations: int = 2, **kwargs) -> NetworkConfig:
+    # Put in own method to isolate `type: ignore` comments
+    return NetworkConfig(required_confirmations=required_confirmations, **kwargs)
+
+
+class BeaconConfig(PluginConfig):
+    mainnet: NetworkConfig = _create_config(block_time=12)
+    goerli: NetworkConfig = _create_config(block_time=12)
+    local: NetworkConfig = _create_local_config()
+    default_network: str = LOCAL_NETWORK_NAME
+
+
+class LighthouseNetworkConfig(PluginConfig):
+    # Make sure you are running the right networks when you try for these
+    mainnet: dict = DEFAULT_SETTINGS.copy()
+    goerli: dict = DEFAULT_SETTINGS.copy()
+    # Make sure to run via `geth --dev` (or similar)
+    local: dict = DEFAULT_SETTINGS.copy()

--- a/ape_beacon/ecosystem.py
+++ b/ape_beacon/ecosystem.py
@@ -1,12 +1,11 @@
 from typing import Dict, Optional, cast
 
-from ape.api.config import PluginConfig
-from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.api.providers import BlockAPI
-from ape_ethereum.ecosystem import Ethereum, NetworkConfig
+from ape_ethereum.ecosystem import Ethereum
 
 from ape_beacon.containers import BeaconBlockBody, BeaconExecutionPayload
 
+from .configs import BeaconConfig
 from .types import attempt_to_hexbytes
 
 NETWORKS = {
@@ -14,22 +13,6 @@ NETWORKS = {
     "mainnet": (1, 1),
     "goerli": (5, 5),
 }
-
-
-def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfig:
-    return _create_config(required_confirmations=0, block_time=0, default_provider=default_provider)
-
-
-def _create_config(required_confirmations: int = 2, **kwargs) -> NetworkConfig:
-    # Put in own method to isolate `type: ignore` comments
-    return NetworkConfig(required_confirmations=required_confirmations, **kwargs)  # type: ignore
-
-
-class BeaconConfig(PluginConfig):
-    mainnet: NetworkConfig = _create_config(block_time=12, default_provider="lighthouse")
-    goerli: NetworkConfig = _create_config(block_time=12, default_provider="lighthouse")
-    local: NetworkConfig = _create_local_config(default_provider="test")
-    default_network: str = LOCAL_NETWORK_NAME
 
 
 class BeaconBlock(BlockAPI):
@@ -45,6 +28,8 @@ class BeaconBlock(BlockAPI):
 
 
 class Beacon(Ethereum):
+    name: str = "beacon"
+
     @property
     def config(self) -> BeaconConfig:  # type: ignore
         return cast(BeaconConfig, self.config_manager.get_config("beacon"))
@@ -62,18 +47,6 @@ class Beacon(Ethereum):
         if "state_root" in data:
             data["hash"] = attempt_to_hexbytes(data.pop("state_root"))
 
-        # limit data retained at block level for beacon operations
-        if "proposer_slashings" in data:
-            data["num_proposer_slashings"] = len(data["proposer_slashings"])
-        if "attester_slashings" in data:
-            data["num_attester_slashings"] = len(data["attester_slashings"])
-        if "attestations" in data:
-            data["num_attestations"] = len(data["attestations"])
-        if "deposits" in data:
-            data["num_deposits"] = len(data["deposits"])
-        if "voluntary_exits" in data:
-            data["num_voluntary_exits"] = len(data["voluntary_exits"])
-
         # init beacon block timestamp and size so doesnt throw validation error if no payload
         data["timestamp"] = 0
         data["size"] = 0
@@ -81,6 +54,18 @@ class Beacon(Ethereum):
         # use data from EL if can (block within a block post-merge)
         payload = None
         if "body" in data:
+            # limit data retained at block level for beacon operations
+            if "proposer_slashings" in data["body"]:
+                data["body"]["num_proposer_slashings"] = len(data["body"].pop("proposer_slashings"))
+            if "attester_slashings" in data["body"]:
+                data["body"]["num_attester_slashings"] = len(data["body"].pop("attester_slashings"))
+            if "attestations" in data["body"]:
+                data["body"]["num_attestations"] = len(data["body"].pop("attestations"))
+            if "deposits" in data["body"]:
+                data["body"]["num_deposits"] = len(data["body"].pop("deposits"))
+            if "voluntary_exits" in data["body"]:
+                data["body"]["num_voluntary_exits"] = len(data["body"].pop("voluntary_exits"))
+
             payload_data = data["body"].pop("execution_payload", None)
             if payload_data is not None:
                 payload_data["size"] = 0  # TODO: infer size from gas limit

--- a/ape_beacon/providers.py
+++ b/ape_beacon/providers.py
@@ -3,17 +3,26 @@ from typing import Iterator, Optional
 
 import requests
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape.api.providers import BlockAPI, ProviderAPI
+from ape.api.providers import BlockAPI, ProviderAPI, UpstreamProvider
 from ape.api.transactions import ReceiptAPI, TransactionAPI
-from ape.exceptions import APINotImplementedError, BlockNotFoundError, ProviderNotConnectedError
+from ape.exceptions import (
+    APINotImplementedError,
+    BlockNotFoundError,
+    ProviderError,
+    ProviderNotConnectedError,
+)
+from ape.logging import logger
 from ape.types import BlockID, ContractLog, LogFilter
 from ape.utils import cached_property
 from eth_typing import HexStr
 from hexbytes import HexBytes
 from web3.beacon import Beacon
+from yarl import URL
 
 from ape_beacon.exceptions import ValidatorNotFoundError
 from ape_beacon.types import convert_block_id
+
+DEFAULT_SETTINGS = {"uri": "http://localhost:5052"}
 
 
 class BeaconProvider(ProviderAPI, ABC):
@@ -27,6 +36,7 @@ class BeaconProvider(ProviderAPI, ABC):
 
     _beacon: Optional[Beacon] = None
     _client_version: Optional[str] = None
+    cached_chain_id: Optional[int] = None
 
     @property
     def beacon(self) -> Beacon:
@@ -122,12 +132,15 @@ class BeaconProvider(ProviderAPI, ABC):
         ) and not self.network.name.endswith("-fork"):
             # If using a live network, the chain ID is hardcoded.
             default_chain_id = self.network.chain_id
+        elif self.cached_chain_id is not None:
+            return self.cached_chain_id  # TODO: test
 
         try:
             # use deposit contract endpoint for chain ID
             resp = self.beacon.get_deposit_contract()
             if "data" in resp and "chain_id" in resp["data"]:
-                return int(resp["data"]["chain_id"])
+                self.cached_chain_id = int(resp["data"]["chain_id"])
+                return self.cached_chain_id
 
         except requests.exceptions.HTTPError:
             if default_chain_id is not None:
@@ -185,3 +198,84 @@ class BeaconProvider(ProviderAPI, ABC):
         for start_block in range(start, stop + 1, page):
             stop_block = min(stop, start_block + page - 1)
             yield start_block, stop_block
+
+
+# SEE: https://github.com/ApeWorX/ape/blob/main/src/ape_geth/provider.py#L147
+class Lighthouse(BeaconProvider, UpstreamProvider):
+    name: str = "lighthouse"
+
+    @property
+    def uri(self) -> str:
+        if "uri" in self.provider_settings:
+            # Use adhoc, scripted value
+            return self.provider_settings["uri"]
+
+        config = self.config.dict().get(self.network.ecosystem.name, None)
+        if config is None:
+            return DEFAULT_SETTINGS["uri"]
+
+        # Use value from config file
+        network_config = config.get(self.network.name)
+        return network_config.get("uri", DEFAULT_SETTINGS["uri"])
+
+    @property
+    def _clean_uri(self) -> str:
+        return str(URL(self.uri).with_user(None).with_password(None))
+
+    @property
+    def connection_str(self) -> str:
+        return self.uri
+
+    def connect(self):
+        self._client_version = None  # Clear cached version when connecting to another URI.
+        self._beacon = Beacon(self.uri)
+
+        if not self.is_connected:
+            # TODO: "ephemeral" lighthouse?
+            raise ProviderError(f"No node found on '{self._clean_uri}'")
+        elif "lighthouse" in self.client_version.lower():
+            self._log_connection("Lighthouse")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "prysm" in self.client_version.lower():
+            self._log_connection("Prysm")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "lodestar" in self.client_version.lower():
+            self._log_connection("Lodestar")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "nimbus" in self.client_version.lower():
+            self._log_connection("Nimbus")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "teku" in self.client_version.lower():
+            self._log_connection("Teku")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        else:
+            client_name = self.client_version.split("/")[0]
+            logger.warning(
+                f"Connecting Lighthouse plugin to non-Lighthouse client '{client_name}'."
+            )
+
+        # Check for chain errors, including syncing
+        try:
+            # use deposit contract endpoint for chain ID
+            resp = self._beacon.get_deposit_contract()
+            chain_id = int(resp["data"]["chain_id"])
+        except (requests.exceptions.HTTPError, KeyError) as err:
+            raise ProviderError(
+                err.args[0].get("message")
+                if all((hasattr(err, "args"), err.args, isinstance(err.args[0], dict)))
+                else "Error getting chain id."
+            )
+
+        self.network.verify_chain_id(chain_id)
+
+    def disconnect(self):
+        self._beacon = None
+        self._client_version = None
+
+    def _log_connection(self, client_name: str):
+        logger.info(f"Connecting to existing {client_name} node at '{self._clean_uri}'.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,11 @@ def accounts():
 
 
 @pytest.fixture(scope="session")
+def chain():
+    return ape.chain
+
+
+@pytest.fixture(scope="session")
 def beacon(networks):
     return networks.beacon
 

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def in_beacon(networks):
+    with networks.parse_network_choice("beacon:local"):
+        yield
+
+
+@pytest.fixture(scope="module")
+def in_ethereum(networks):
+    with networks.parse_network_choice("ethereum:local"):
+        yield
+
+
+# SEE: https://beaconcha.in/slot/1213760
+# TODO: def test_in_beacon(in_beacon, networks, chain):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -2,6 +2,7 @@ from ape_beacon.containers import BeaconExecutionPayload
 
 # NOTE: testing success cases given time constraints
 # TODO: testing non-success
+# TODO: better testing around expect, particuarly on data truncation with len()
 
 
 def test_decode_block_when_no_payload(beacon):


### PR DESCRIPTION
### What I did

Added a `Lighthouse` provider for interacting with a lighthouse beacon chain node.

### How I did it

Copied `ape_geth.provider.GethProvider`

### How to verify it

Run a local lighthouse node

```bash
lighthouse bn --http
```

then with ape console

```python
with networks.parse_network_choice("beacon:mainnet"):
   beacon_block = chain.blocks[-1]
```

should yield a beacon block.


### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
