### PR TITLE
fix: network config to allow extra for default provider

### DIFF
--- a/ape_beacon/configs.py
+++ b/ape_beacon/configs.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from ape.api import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
+from pydantic import Extra
 
 from .providers import DEFAULT_SETTINGS
 
@@ -9,6 +10,9 @@ from .providers import DEFAULT_SETTINGS
 class NetworkConfig(PluginConfig):
     required_confirmations: int = 0
     block_time: int = 0
+
+    class Config:
+        extra = Extra.allow
 
 
 def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:


### PR DESCRIPTION
### What I did

Fixed a bug with `NetworkConfig` not allowing `default_provider` to be passed in.

### How I did it

Added pydantic allow extra fields for `NetworkConfig` class in `configs.py`.

### How to verify it

Using [`consensus-ape`](https://github.com/fmrmf/consensus-ape), simply

```bash
ape console
```

then should get a beacon block for

```python
$ ape console                                                                       
ERROR: Failed setting default provider: Provider 'lighthouse' not found in network 'mainnet'.
INFO: Connecting to existing Lighthouse node at 'http://localhost:5052'.

In [1]: chain
Out[1]: <ChainManager (id=1)>

In [2]: chain.blocks[-1]
Out[2]: BeaconBlock(num_transactions=0, hash=HexBytes('0x2f84c2832caa6d3840dc26c3e2123dc4fd24ad57e462287794d765c73001bd9f'), number=1246688, parent_hash=HexBytes('0xffde7d515971f3e675d27f98690e6f1bff7dfd84626e3dfd84716203142599a3'), size=0, timestamp=0, proposer_index=41751, body=BeaconBlockBody(randao_reveal=HexBytes('0x83928c95523e9a32404c02545acf60fb4fd2eafc4f5c96143ddb126f93355377b53cf6598510fdfeab3a8dc18a1cc43211b34cb99a4b649610732ab8d14d80a37c303a7c0872638b9cb393e2f1a8ff7002d887a56a0afb2276ea24576de6bf81'), eth1_data=Eth1Data(deposit_root=HexBytes('0x073574189ea3a62bd04c7ed0c9cc2e2d44649553018440e2e2b49ce0abfe695c'), deposit_count=150281, block_hash=HexBytes('0x4902b891d5607e58f76e0af2a06cbbb4dd09c13ec6440faa1ccab7c1e035842c')), graffiti=HexBytes('0x68756f6269706f6f6c0000000000000000000000000000000000000000000000'), num_proposer_slashings=0, num_attester_slashings=0, num_attestations=70, num_deposits=0, num_voluntary_exits=0, sync_aggregate=None, execution_payload=None))

In [3]: 
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
